### PR TITLE
Refactor error page root

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -187,7 +187,7 @@ void Config::parseErrorPage(std::string &value) {
 	for (it = argv.begin(); it != argv.end(); it++) {
 		errorCode = getErrorCode(*it);
 		if (errorCode % 100 == 0)
-			_errorPage[errorCode] = uri;
+			_errorPage[errorCode] = _root + '/' + uri;
 		else
 			warnErrorCode(errorCode);
 	}

--- a/src/error/Error.cpp
+++ b/src/error/Error.cpp
@@ -30,7 +30,7 @@ uint8_t clientException::getMethodMask() const {return (_methodMask);}
 
 serverException::serverException(Config const * config) {
 	if (config != NULL)
-		_errorPage = config->getRoot() + '/' + config->getErrorPage()[SERVER_ERROR_STATUS_CODE];
+		_errorPage = config->getErrorPage()[SERVER_ERROR_STATUS_CODE];
 }
 
 serverException::~serverException() throw() {}
@@ -39,7 +39,7 @@ std::string serverException::getErrorPage() const {return (_errorPage);}
 
 redirectionException::redirectionException(const Config *config) {
 	if (config != NULL)
-		_errorPage = config->getRoot() + '/' + config->getErrorPage()[REDIRECTION_STATUS_CODE];
+		_errorPage = config->getErrorPage()[REDIRECTION_STATUS_CODE];
 }
 
 redirectionException::~redirectionException() throw() {}

--- a/src/error/Error.cpp
+++ b/src/error/Error.cpp
@@ -14,11 +14,11 @@
 
 clientException::clientException(Config const * config): _methodMask(0b01111000) {
 	if (config != NULL)
-		_errorPage = config->getRoot() + '/' + config->getErrorPage()[CLIENT_ERROR_STATUS_CODE];
+		_errorPage = config->getErrorPage()[CLIENT_ERROR_STATUS_CODE];
 }
 
 clientException::clientException(Config const * config, uint8_t methodMask) {
-	_errorPage = config->getRoot() + '/' + config->getErrorPage()[CLIENT_ERROR_STATUS_CODE];
+	_errorPage = config->getErrorPage()[CLIENT_ERROR_STATUS_CODE];
 	_methodMask = methodMask;
 }
 


### PR DESCRIPTION
Add root to error page in parseErrorPage() instead of in the client / server exception